### PR TITLE
Adding enum value to fix the build

### DIFF
--- a/XboxWebApi/Services/Model/X360Marketplace/CatalogOverviewRequestQuery.cs
+++ b/XboxWebApi/Services/Model/X360Marketplace/CatalogOverviewRequestQuery.cs
@@ -29,7 +29,7 @@ namespace XboxWebApi.Services.Model.X360Marketplace
             Store = 1;
             PageSize = 25;
             PageNum = 1;
-            DetailView = CatalogDetailLevel.IncludeBanner;
+            DetailView = CatalogDetailLevel.IncludeBoxart;
             OfferFilterLevel = 1;
             CategoryIDs = 3027;
             OrderBy = 1;


### PR DESCRIPTION
Noticed the build was broken. It looks like the `IncludeBanner` value was removed from the `CatalogDetailLevel` enumeration. 