### PR TITLE
Allowing the RestClientEx class to be mocked

### DIFF
--- a/XboxWebApi.Tests/Services/TestAccountService.cs
+++ b/XboxWebApi.Tests/Services/TestAccountService.cs
@@ -1,0 +1,56 @@
+﻿using Moq;
+using NUnit.Framework;
+using RestSharp;
+using System.Collections.Generic;
+using XboxWebApi.Authentication;
+using XboxWebApi.Extensions;
+using XboxWebApi.Services;
+using XboxWebApi.Services.Api;
+using XboxWebApi.Services.Model.Account;
+
+namespace XboxWebApi.Tests.Services
+{
+    public class TestAccountService
+    {
+        [Test]
+        [Category("unit")]
+        public void GetFamilyAccount_Request()
+        {
+            //Assemble
+            const ulong xuid = 1234567890;
+            IRestRequest request = null;
+
+            var parameters = new List<Parameter>();
+
+            var mock = new Mock<IRestSharpEx>();
+            mock.Setup(r => r.DefaultParameters).Returns(parameters);
+            
+            mock.SetupGenericExecute<AccountResponse>()
+                .Callback((IRestRequest req) =>
+                {
+                    request = req;
+                })
+                .AddGenericExecuteResponse(new RestResponse<AccountResponse>());
+
+            var token = new XToken
+            {
+                Jwt = string.Empty
+            };
+
+            var configMock = new Mock<IXblConfiguration>();
+            configMock.Setup(c => c.Userhash).Returns(string.Empty);
+            configMock.Setup(c => c.xToken).Returns(token);
+
+            var sut = new AccountService(configMock.Object, mock.Object);
+
+            //Act
+            sut.GetFamilyAccount(xuid);
+
+            //Assert
+            Assert.IsNotNull(request);
+            Assert.IsNotNull(request.Resource);
+            Assert.IsNotEmpty(request.Resource);
+            Assert.IsTrue(request.Resource.Contains(xuid.ToString()));
+        }
+    }
+}

--- a/XboxWebApi.Tests/Services/TestAchievementService.cs
+++ b/XboxWebApi.Tests/Services/TestAchievementService.cs
@@ -1,0 +1,51 @@
+using Moq;
+using NUnit.Framework;
+using RestSharp;
+using System.Collections.Generic;
+using XboxWebApi.Authentication;
+using XboxWebApi.Extensions;
+
+namespace XboxWebApi.Services.Api
+{
+    public class TestAchievementService
+    {
+        [Test]
+        [Category("unit")]
+        public void GetAchievementGameprogress_Request()
+        {
+            //Assemble
+            const ulong xuid = 1234567890;
+            const ulong titleId = 10987654321;
+            IRestRequest request = null;
+
+            var parameters = new List<Parameter>();
+
+            var mock = new Mock<IRestSharpEx>();
+            mock.Setup(r => r.DefaultParameters).Returns(parameters);
+
+            mock.Setup(r => r.Execute(It.IsAny<RestRequestEx>()))
+                .Callback((IRestRequest req) => { request = req; })
+                .Returns(new RestResponse());
+
+            var token = new XToken
+            {
+                Jwt = string.Empty
+            };
+
+            var configMock = new Mock<IXblConfiguration>();
+            configMock.Setup(c => c.Userhash).Returns(string.Empty);
+            configMock.Setup(c => c.xToken).Returns(token);
+
+            var sut = new AchievementService(configMock.Object, mock.Object);
+
+            //Act
+            sut.GetAchievementGameprogress(xuid, titleId);
+
+            //Assert
+            Assert.IsNotNull(request);
+            Assert.IsNotNull(request.Resource);
+            Assert.IsNotEmpty(request.Resource);
+            Assert.IsTrue(request.Resource.Contains(xuid.ToString()));
+        }
+    }
+}

--- a/XboxWebApi.Tests/TestExtensions.cs
+++ b/XboxWebApi.Tests/TestExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Moq;
+using Moq.Language.Flow;
+using RestSharp;
+using XboxWebApi.Extensions;
+
+namespace XboxWebApi.Tests
+{
+    public static class TestExtensions
+    {
+        public static ISetup<IRestSharpEx, IRestResponse<T>> SetupGenericExecute<T>(this Mock<IRestSharpEx> client) 
+            where T : class, new() =>
+                client.Setup(r => r.Execute<T>(It.IsAny<RestRequestEx>()));
+
+        public static void AddGenericExecuteResponse<T>(
+            this IReturnsThrows<IRestSharpEx, IRestResponse<T>> setup,
+            RestResponse<T> response) 
+                where T : class, new() => 
+                    setup.Returns(response);
+    }
+}

--- a/XboxWebApi.Tests/XboxWebApi.Tests.csproj
+++ b/XboxWebApi.Tests/XboxWebApi.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />

--- a/XboxWebApi/Extensions/IRestSharpEx.cs
+++ b/XboxWebApi/Extensions/IRestSharpEx.cs
@@ -1,0 +1,10 @@
+﻿using RestSharp;
+using XboxWebApi.Common;
+
+namespace XboxWebApi.Extensions
+{
+    public interface IRestSharpEx : IRestClient
+    {
+        void SetSerializer(NewtonsoftJsonSerializer serializer);
+    }
+}

--- a/XboxWebApi/Services/Api/AccountService.cs
+++ b/XboxWebApi/Services/Api/AccountService.cs
@@ -10,17 +10,17 @@ namespace XboxWebApi.Services.Api
 {
     public class AccountService : XblService
     {
-        public AccountService(XblConfiguration config)
-            : base(config, "https://accounts.xboxlive.com")
-        {   
+        public AccountService(IXblConfiguration config, IRestSharpEx httpClient)
+            : base(config, "https://accounts.xboxlive.com", httpClient)
+        {
         }
 
         public AccountResponse GetAccount()
         {
             RestRequestEx request = new RestRequestEx("users/current/profile", Method.GET);
             // No headers
-            IRestResponse<AccountResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<AccountResponse>(request);
+            IRestResponse<AccountResponse> response = HttpClient.Execute<AccountResponse>(request);
+
             return response.Data;
         }
 
@@ -28,8 +28,8 @@ namespace XboxWebApi.Services.Api
         {
             RestRequestEx request = new RestRequestEx($"family/memberXuid({xuid})", Method.GET);
             // No headers
-            IRestResponse<AccountResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<AccountResponse>(request);
+            IRestResponse<AccountResponse> response = HttpClient.Execute<AccountResponse>(request);
+
             return response.Data;
         }
     }

--- a/XboxWebApi/Services/Api/AchievementService.cs
+++ b/XboxWebApi/Services/Api/AchievementService.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using RestSharp;
-using XboxWebApi.Common;
 using XboxWebApi.Extensions;
 using XboxWebApi.Services.Model.Achievement;
 
@@ -13,12 +11,13 @@ namespace XboxWebApi.Services.Api
         private NameValueCollection Headers_XONE;
         private NameValueCollection Headers_X360;
 
-        public AchievementService(XblConfiguration config)
-            : base(config, "https://achievements.xboxlive.com")
+        public AchievementService(IXblConfiguration config, IRestSharpEx httpClient)
+            : base(config, "https://achievements.xboxlive.com", httpClient)
         {
             Headers_X360 = new NameValueCollection(){
                 {"x-xbl-contract-version", "1"}
             };
+
             Headers_XONE = new NameValueCollection(){
                 {"x-xbl-contract-version", "2"}
             };
@@ -29,8 +28,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx(
                 $"users/xuid({xuid})/achievements/{scid}/{achievementId}", Method.GET);
             request.AddHeaders(Headers_XONE);
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+            
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
 
@@ -41,8 +40,8 @@ namespace XboxWebApi.Services.Api
                 $"users/xuid({xuid})/achievements", Method.GET);
             request.AddHeaders(Headers_XONE);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+            
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
 
@@ -51,8 +50,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx(
                 $"users/xuid({xuid})/history/titles", Method.GET);
             request.AddHeaders(Headers_XONE);
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
 
@@ -63,8 +62,8 @@ namespace XboxWebApi.Services.Api
                 $"users/xuid({xuid})/titleachievements", Method.GET);
             request.AddHeaders(Headers_X360);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+            
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
 
@@ -75,8 +74,8 @@ namespace XboxWebApi.Services.Api
                 $"users/xuid({xuid})/achievements", Method.GET);
             request.AddHeaders(Headers_X360);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
 
@@ -85,8 +84,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx(
                 $"users/xuid({xuid})/history/titles", Method.GET);
             request.AddHeaders(Headers_X360);
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
     }

--- a/XboxWebApi/Services/Api/CQSService.cs
+++ b/XboxWebApi/Services/Api/CQSService.cs
@@ -10,8 +10,8 @@ namespace XboxWebApi.Services.Api
 {
     public class CQSService : XblService
     {
-        public CQSService(XblConfiguration config)
-            : base(config, "https://cqs.xboxlive.com")
+        public CQSService(IXblConfiguration config, IRestSharpEx httpClient)
+            : base(config, "https://cqs.xboxlive.com", httpClient)
         {
             Headers = new NameValueCollection(){
                 {"Cache-Control", "no-cache"},
@@ -32,8 +32,8 @@ namespace XboxWebApi.Services.Api
                 $"epg/{localeInfo}/lineups/{headendId}/channels", Method.GET);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
 
@@ -47,8 +47,8 @@ namespace XboxWebApi.Services.Api
                 $"epg/{localeInfo}/lineups/{headendId}/programs", Method.GET);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
     }

--- a/XboxWebApi/Services/Api/EDSService.cs
+++ b/XboxWebApi/Services/Api/EDSService.cs
@@ -10,8 +10,8 @@ namespace XboxWebApi.Services.Api
 {
     public class EDSService : XblService
     {
-        public EDSService(XblConfiguration config)
-            : base(config, "https://eds.xboxlive.com")
+        public EDSService(IXblConfiguration config, IRestSharpEx httpClient)
+            : base(config, "https://eds.xboxlive.com", httpClient)
         {
             Headers = new NameValueCollection(){
                 {"Cache-Control", "no-cache"},
@@ -32,8 +32,8 @@ namespace XboxWebApi.Services.Api
                 $"media/{this.Config.Locale.Locale}/tvchannels", Method.GET);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
 
@@ -47,8 +47,8 @@ namespace XboxWebApi.Services.Api
                 $"epg/{localeInfo}/lineups/{headendId}/programs", Method.GET);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
             Console.WriteLine(response.Content);
         }
     }

--- a/XboxWebApi/Services/Api/MessageService.cs
+++ b/XboxWebApi/Services/Api/MessageService.cs
@@ -10,8 +10,8 @@ namespace XboxWebApi.Services.Api
 {
     public class MessageService : XblService
     {
-        public MessageService(XblConfiguration config)
-            : base(config, "https://msg.xboxlive.com")
+        public MessageService(IXblConfiguration config, IRestSharpEx httpClient)
+            : base(config, "https://msg.xboxlive.com", httpClient)
         {
             Headers = new NameValueCollection()
             {
@@ -27,8 +27,8 @@ namespace XboxWebApi.Services.Api
                 $"users/xuid({Config.XboxUserId})/inbox", Method.GET);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse<MessageInboxResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<MessageInboxResponse>(request);
+
+            IRestResponse<MessageInboxResponse> response = HttpClient.Execute<MessageInboxResponse>(request);
             return response.Data;
         }
 
@@ -37,8 +37,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx(
                 $"users/xuid({Config.XboxUserId})/inbox/{messageId}", Method.GET);
             request.AddHeaders(Headers);
-            IRestResponse<MessageResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<MessageResponse>(request);
+
+            IRestResponse<MessageResponse> response = HttpClient.Execute<MessageResponse>(request);
             return response.Data;
         }
 
@@ -50,8 +50,8 @@ namespace XboxWebApi.Services.Api
                 $"users/xuid({Config.XboxUserId})/inbox/conversations", Method.GET);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse<ConversationsResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<ConversationsResponse>(request);
+
+            IRestResponse<ConversationsResponse> response = HttpClient.Execute<ConversationsResponse>(request);
             return response.Data;
         }
 
@@ -60,8 +60,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx(
                 $"users/xuid({Config.XboxUserId})/inbox/conversations/xuid({xuid})", Method.GET);
             request.AddHeaders(Headers);
-            IRestResponse<ConversationResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<ConversationResponse>(request);
+
+            IRestResponse<ConversationResponse> response = HttpClient.Execute<ConversationResponse>(request);
             return response.Data;
         }
 
@@ -70,8 +70,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx(
                 $"users/xuid({Config.XboxUserId})/inbox/{messageId}", Method.DELETE);
             request.AddHeaders(Headers);
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
         }
 
         private void SendMessage(MessageSendRequest postData)
@@ -80,8 +80,8 @@ namespace XboxWebApi.Services.Api
                 $"users/xuid({Config.XboxUserId})/outbox", Method.POST);
             request.AddHeaders(Headers);
             request.AddJsonBody(postData, JsonNamingStrategy.CamelCase);
-            IRestResponse response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute(request);
+
+            IRestResponse response = HttpClient.Execute(request);
         }
 
         public void SendMessage(string messageText, ulong[] xuids)

--- a/XboxWebApi/Services/Api/PeopleService.cs
+++ b/XboxWebApi/Services/Api/PeopleService.cs
@@ -10,8 +10,8 @@ namespace XboxWebApi.Services.Api
 {
     public class PeopleService : XblService
     {
-        public PeopleService(XblConfiguration config)
-            : base(config, "https://social.xboxlive.com")
+        public PeopleService(IXblConfiguration config, IRestSharpEx httpClient)
+            : base(config, "https://social.xboxlive.com", httpClient)
         {
             Headers = new NameValueCollection()
             {
@@ -23,8 +23,8 @@ namespace XboxWebApi.Services.Api
         {
             RestRequestEx request = new RestRequestEx("users/me/people", Method.GET);
             request.AddHeaders(Headers);
-            IRestResponse<PeopleResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<PeopleResponse>(request);
+
+            IRestResponse<PeopleResponse> response = HttpClient.Execute<PeopleResponse>(request);
             return response.Data;
         }
 
@@ -32,8 +32,8 @@ namespace XboxWebApi.Services.Api
         {
             RestRequestEx request = new RestRequestEx("users/me/summary", Method.GET);
             request.AddHeaders(Headers);
-            IRestResponse<PeopleSummaryResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<PeopleSummaryResponse>(request);
+
+            IRestResponse<PeopleSummaryResponse> response = HttpClient.Execute<PeopleSummaryResponse>(request);
             return response.Data;
         }
 
@@ -41,8 +41,8 @@ namespace XboxWebApi.Services.Api
         {
             RestRequestEx request = new RestRequestEx($"users/xuid({xuid})/summary", Method.GET);
             request.AddHeaders(Headers);
-            IRestResponse<PeopleSummaryResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<PeopleSummaryResponse>(request);
+
+            IRestResponse<PeopleSummaryResponse> response = HttpClient.Execute<PeopleSummaryResponse>(request);
             return response.Data;
         }
 
@@ -50,8 +50,8 @@ namespace XboxWebApi.Services.Api
         {
             RestRequestEx request = new RestRequestEx($"users/gt({gamertag})/summary", Method.GET);
             request.AddHeaders(Headers);
-            IRestResponse<PeopleSummaryResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<PeopleSummaryResponse>(request);
+
+            IRestResponse<PeopleSummaryResponse> response = HttpClient.Execute<PeopleSummaryResponse>(request);
             return response.Data;
         }
 
@@ -61,8 +61,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx("users/me/people/xuids", Method.POST);
             request.AddHeaders(Headers);
             request.AddJsonBody(body, JsonNamingStrategy.CamelCase);
-            IRestResponse<PeopleResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<PeopleResponse>(request);
+
+            IRestResponse<PeopleResponse> response = HttpClient.Execute<PeopleResponse>(request);
             return response.Data;
         }
     }

--- a/XboxWebApi/Services/Api/PresenceService.cs
+++ b/XboxWebApi/Services/Api/PresenceService.cs
@@ -10,8 +10,8 @@ namespace XboxWebApi.Services.Api
 {
     public class PresenceService : XblService
     {
-        public PresenceService(XblConfiguration config)
-            : base(config, "https://userpresence.xboxlive.com")
+        public PresenceService(IXblConfiguration config, IRestSharpEx httpClient)
+            : base(config, "https://userpresence.xboxlive.com", httpClient)
         {
             Headers = new NameValueCollection()
             {
@@ -25,8 +25,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx("users/me", Method.GET);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse<PresenceResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<PresenceResponse>(request);
+
+            IRestResponse<PresenceResponse> response = HttpClient.Execute<PresenceResponse>(request);
             return response.Data;
         }
 
@@ -36,8 +36,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx($"users/xuid({xuid})", Method.GET);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse<PresenceResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<PresenceResponse>(request);
+
+            IRestResponse<PresenceResponse> response = HttpClient.Execute<PresenceResponse>(request);
             return response.Data;
         }
 
@@ -49,8 +49,8 @@ namespace XboxWebApi.Services.Api
             RestRequestEx request = new RestRequestEx("users/batch", Method.POST);
             request.AddHeaders(Headers);
             request.AddJsonBody(body, JsonNamingStrategy.CamelCase);
-            IRestResponse<PresenceBatchResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<PresenceBatchResponse>(request);
+
+            IRestResponse<PresenceBatchResponse> response = HttpClient.Execute<PresenceBatchResponse>(request);
             return response.Data;
         }
     }

--- a/XboxWebApi/Services/Api/ProfileService.cs
+++ b/XboxWebApi/Services/Api/ProfileService.cs
@@ -10,8 +10,8 @@ namespace XboxWebApi.Services.Api
 {
     public class ProfileService : XblService
     {
-        public ProfileService(XblConfiguration config)
-            : base(config, "https://profile.xboxlive.com")
+        public ProfileService(IXblConfiguration config, IRestSharpEx httpClient)
+            : base(config, "https://profile.xboxlive.com", httpClient)
         {
             Headers = new NameValueCollection()
             {
@@ -32,8 +32,8 @@ namespace XboxWebApi.Services.Api
             ProfilesRequest body = new ProfilesRequest(xuids, profileSettings);
             request.AddHeaders(Headers);
             request.AddJsonBody(body, JsonNamingStrategy.CamelCase);
-            IRestResponse<ProfileResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<ProfileResponse>(request);
+
+            IRestResponse<ProfileResponse> response = HttpClient.Execute<ProfileResponse>(request);
             return response.Data;
         }
 
@@ -49,8 +49,8 @@ namespace XboxWebApi.Services.Api
             ProfileRequestQuery query = new ProfileRequestQuery(profileSettings);
             request.AddHeaders(Headers);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse<ProfileResponse> response = ClientFactory(JsonNamingStrategy.CamelCase)
-                .Execute<ProfileResponse>(request);
+
+            IRestResponse<ProfileResponse> response = HttpClient.Execute<ProfileResponse>(request);
             return response.Data;
         }
 

--- a/XboxWebApi/Services/Api/X360CatalogService.cs
+++ b/XboxWebApi/Services/Api/X360CatalogService.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using RestSharp;
+using XboxWebApi.Common;
+using XboxWebApi.Extensions;
+using XboxWebApi.Services.Model.X360Marketplace;
+
+namespace XboxWebApi.Services.Api
+{
+    public class X360CatalogService
+    {
+        private readonly IRestClient _httpClient;
+
+        public XblLocale Locale { get; internal set ;}
+
+        public string UserAgent;
+        public X360CatalogService(XblLocale locale, IRestClient httpClient)
+        {
+            _httpClient = httpClient;
+            _httpClient.BaseUrl = new Uri("http://catalog.xboxlive.com");
+
+            Locale = locale;
+            UserAgent = "Xbox Live Client/2.0.17526.0";
+        }
+
+        public CatalogOverviewResponse GetCatalogOverview()
+        {
+            CatalogOverviewRequestQuery query = new CatalogOverviewRequestQuery(Locale);
+            
+            RestRequestEx request = new RestRequestEx(
+                $"Catalog/Catalog.asmx/Query", Method.GET);
+            List<Tuple<string, string>> q = query.GetQuery();
+            // Query contains duplicate keys, hence following add-method
+            q.ForEach(x => request.AddQueryParameter(x.Item1, x.Item2));
+
+            IRestResponse<CatalogOverviewResponse> response = _httpClient.Execute<CatalogOverviewResponse>(request);
+            return response.Data;
+        }
+    }
+}

--- a/XboxWebApi/Services/Api/X360MarketplaceService.cs
+++ b/XboxWebApi/Services/Api/X360MarketplaceService.cs
@@ -10,58 +10,38 @@ namespace XboxWebApi.Services.Api
 {
     public class X360MarketplaceService
     {
+        private readonly IRestClient _httpClient;
+
         public XblLocale Locale { get; internal set ;}
 
         public string UserAgent;
-        public X360MarketplaceService(XblLocale locale)
+        public X360MarketplaceService(XblLocale locale, IRestClient httpClient)
         {
+            _httpClient = httpClient;
+            _httpClient.BaseUrl = new Uri("http://marketplace-xb.xboxlive.com");
+
             Locale = locale;
             UserAgent = "Xbox Live Client/2.0.17526.0";
-        }
-
-        public RestClientEx ClientFactory(string baseUrl, JsonNamingStrategy naming)
-        {
-            RestClientEx client = new RestClientEx(baseUrl, naming);
-            client.AddDefaultHeader("User-Agent", UserAgent);
-            return client;
         }
 
         public CatalogItemResponse GetCatalogItem(Guid productId)
         {
             CatalogItemRequestQuery query = new CatalogItemRequestQuery();
-            RestClient client = ClientFactory(
-                "http://marketplace-xb.xboxlive.com", JsonNamingStrategy.Default);
+            
             RestRequestEx request = new RestRequestEx(
                 $"marketplacecatalog/v1/product/{Locale.Locale}/{productId}", Method.GET);
             request.AddQueryParameters(query.GetQuery());
-            IRestResponse<CatalogItemResponse> response = client
+            
+            IRestResponse<CatalogItemResponse> response = _httpClient
                 .Execute<CatalogItemResponse>(request);
             Console.WriteLine(response.Content);
             return response.Data;
         }
 
-        public CatalogOverviewResponse GetCatalogOverview()
-        {
-            CatalogOverviewRequestQuery query = new CatalogOverviewRequestQuery(Locale);
-            RestClient client = ClientFactory(
-                "http://catalog.xboxlive.com", JsonNamingStrategy.Default);
-            RestRequestEx request = new RestRequestEx(
-                $"Catalog/Catalog.asmx/Query", Method.GET);
-            List<Tuple<string, string>> q = query.GetQuery();
-            // Query contains duplicate keys, hence following add-method
-            q.ForEach(x => request.AddQueryParameter(x.Item1, x.Item2));
-            IRestResponse<CatalogOverviewResponse> response = client
-                .Execute<CatalogOverviewResponse>(request);
-            return response.Data;
-        }
-
-        public Uri GetDownloadUrl(string titleId, string xcpFilename)
-        {
-            RestClient client = ClientFactory(
-                "http://download.xboxlive.com", JsonNamingStrategy.Default);
-            RestRequestEx request = new RestRequestEx(
-                $"content/{titleId}/{xcpFilename}", Method.GET);
-            return client.BuildUri(request);
-        }
+        public Uri GetDownloadUrl(string titleId, string xcpFilename) =>
+            new Uri(
+                new Uri("http://download.xboxlive.com"), 
+                new Uri($"content/{titleId}/{xcpFilename}")
+            );
     }
 }

--- a/XboxWebApi/Services/Model/IXblConfiguration.cs
+++ b/XboxWebApi/Services/Model/IXblConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Specialized;
+using RestSharp;
+using XboxWebApi.Authentication;
+using XboxWebApi.Authentication.Model;
+
+namespace XboxWebApi.Services
+{
+    public interface IXblConfiguration
+    {
+        XToken xToken { get; }
+        XblLocale Locale { get; }
+
+        XboxUserInformation UserInfo { get; }
+        ulong XboxUserId { get; }
+        string Userhash { get; }
+        bool TokenValid { get; }
+    }
+}

--- a/XboxWebApi/Services/XblConfiguration.cs
+++ b/XboxWebApi/Services/XblConfiguration.cs
@@ -6,7 +6,7 @@ using XboxWebApi.Authentication.Model;
 
 namespace XboxWebApi.Services
 {
-    public class XblConfiguration
+    public class XblConfiguration : IXblConfiguration
     {
         public XToken xToken { get; internal set; }
         public XblLocale Locale { get; internal set; }

--- a/XboxWebApi/Services/XblService.cs
+++ b/XboxWebApi/Services/XblService.cs
@@ -8,20 +8,21 @@ namespace XboxWebApi.Services
 {
     public class XblService
     {
+        protected IRestSharpEx HttpClient { get; }
+
         public string BaseUrl { get; internal set; }
         public NameValueCollection Headers { get; internal set; }
-        public XblConfiguration Config { get; internal set; }
-        public XblService(XblConfiguration config, string baseUrl)
+        public IXblConfiguration Config { get; internal set; }
+        public XblService(IXblConfiguration config, string baseUrl, IRestSharpEx httpClient)
         {
             Config = config;
             BaseUrl = baseUrl;
-        }
 
-        public RestClientEx ClientFactory(JsonNamingStrategy namingStrategy = JsonNamingStrategy.Default)
-        {
-            RestClientEx client = new RestClientEx(BaseUrl, namingStrategy);
-            client.AddDefaultHeader("Authorization", $"XBL3.0 x={Config.Userhash};{Config.xToken.Jwt}");
-            return client;
+            HttpClient = httpClient;
+            Console.WriteLine("ParamsNull: " + (HttpClient.DefaultParameters == null));
+            HttpClient.BaseUrl = new Uri(baseUrl);
+            HttpClient.AddDefaultHeader("Authorization", $"XBL3.0 x={Config.Userhash};{Config.xToken.Jwt}");
+            HttpClient.SetSerializer(NewtonsoftJsonSerializer.CamelCase);
         }
     }
 }

--- a/XboxWebApi/XboxWebApi.csproj
+++ b/XboxWebApi/XboxWebApi.csproj
@@ -20,13 +20,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Common\" />
-    <Folder Include="Extensions\" />
     <Folder Include="Authentication\" />
     <Folder Include="Authentication\Token\" />
     <Folder Include="Authentication\Model\" />
-    <Folder Include="Services\" />
-    <Folder Include="Services\Api\" />
-    <Folder Include="Services\Model\" />
     <Folder Include="Services\Model\People\" />
     <Folder Include="Services\Model\Presence\" />
     <Folder Include="Services\Model\Profile\" />


### PR DESCRIPTION
This is to address issue #1 .

I changed all of the services to allow for `RestClientEx` to be mocked by applying the `IRestClientEx` interface to the `RestClientEx` and injecting the interface into the services.

 I did have to break out `X360CatalogService` from `X360MarketplaceService` since they each have separate base URLs.

Let me know what you think! 😃 