### PR TITLE
Fix invalid authentication header

### DIFF
--- a/XboxWebApi/Services/XblService.cs
+++ b/XboxWebApi/Services/XblService.cs
@@ -22,7 +22,7 @@ namespace XboxWebApi.Services
             HttpClient.BaseAddress = new Uri(baseUrl);
             
             HttpClient.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue($"XBL3.0 x={Config.Userhash};{Config.xToken.Jwt}");
+                new AuthenticationHeaderValue("XBL3.0",$"x={Config.Userhash};{Config.xToken.Jwt}");
         }
     }
 }


### PR DESCRIPTION
No more "The format of value 'XBL3.0 '...' is invalid." as reported in #16.

The issue could be reproduced by extending the CLI sample with the following calls at line 128:

```csharp
var config = new XblConfiguration(authenticator.XToken, XblLanguage.United_States);
var presenceService = new PresenceService(config);
var presence = await presenceService.GetPresenceAsync();
```